### PR TITLE
Allow passing data-properties to menu items.

### DIFF
--- a/jquery.ui-contextmenu.js
+++ b/jquery.ui-contextmenu.js
@@ -306,10 +306,8 @@ $.extend($.moogle.contextmenu, {
 			if(entry.disabled){
 				$parentLi.addClass("ui-state-disabled");
 			}
-			if(entry.data && $.isPlainObject(entry.data)){
-				$.each(entry.data, function (key, val) {
-					$a.data(key, val);
-				});
+			if($.isPlainObject(entry.data)){
+				$a.data(entry.data);
 			}
 		}
 		return $a;


### PR DESCRIPTION
I needed to attach data-properties to each menu item (created in a loop) and therefore added this.

Usage:

```
menu: [
  { title: 'item a', data: { id: 123, 'some-other-property': 42, action: ... }
]
```

which adds `data-id="123" data-some-other-property="42"` to the a-element.

BTW: Thanks for a nice plugin :)
