### PR TITLE
allow setting custom href attribute

### DIFF
--- a/jquery.ui-contextmenu.js
+++ b/jquery.ui-contextmenu.js
@@ -295,7 +295,7 @@ $.extend($.moogle.contextmenu, {
 		}else{
 			$a = $("<a>", {
 				text: "" + entry.title,
-				href: "#" + normCommand(entry.cmd)
+				href: entry.href? entry.href :"#" + normCommand(entry.cmd)
 			}).appendTo($parentLi);
 			if( $.isFunction(entry.action) ){
 				$a.data("actionHandler", entry.action);


### PR DESCRIPTION
I want to be able to set a custom href attribute in the context menu markup that would be more useful than the default "#cmd". This would allow a user to right click a context menu option and choose to open the link in a new tab or window. It also might be useful for a file download option if the user would like to save it to a custom location.

```
$("#mydiv").contextmenu("setEntry", "search", {title: 'go to google', href: 'www.google.com'});
```
