### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ First, include dependencies:
 * jQuery UI 1.9+ (at least core, widget, menu), 1.11+ recommended
 * One of the ThemeRoller CSS themes or a custom one
 * jquery.ui-contextmenu.js (also available as CDN on
-  [jsDelivr](https://cdn.jsdelivr.net/gh/mar10/jquery-ui-contextmenu/),
+  [jsDelivr](https://www.jsdelivr.com/package/npm/ui-contextmenu),
   [cdnjs](https://cdnjs.com/libraries/jquery.ui-contextmenu), or
   [UNPKG](https://unpkg.com/ui-contextmenu@latest/jquery.ui-contextmenu.min.js))
 


### PR DESCRIPTION
While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the link to use our npm endpoint.

Feel free to ping me if you have any questions regarding this change.