### PR TITLE
Sample patch to enable hyphens as title

### DIFF
--- a/demo/index-1-12.html
+++ b/demo/index-1-12.html
@@ -80,6 +80,14 @@ $(function(){
 		loadTheme: "Base"
 	});
 */
+	/* SAMPLE for issue #136: globally disable hyphen detection. */
+	$.ui.menu.prototype._isDivider = function(item) {
+		console.log("_isDivider", this, arguments);
+		// Match hyphen, em dash, en dash
+		// return !/[^\-\u2014\u2013\s]/.test( item.text() );
+		// return false;
+		return item.text() === "----";
+	};
 	/* Menu 1: init by passing an array of entries. */
 
 	$(document).contextmenu({
@@ -93,6 +101,8 @@ $(function(){
 			{title: "Cut <kbd>Ctrl+X</kbd>", cmd: "cut", uiIcon: "ui-icon-scissors"},
 			{title: "Copy <kbd>Ctrl+C</kbd>", cmd: "copy", uiIcon: "ui-icon-copy"},
 			{title: "Paste <kbd>Ctrl+V</kbd>", cmd: "paste", uiIcon: "ui-icon-clipboard", disabled: true },
+			{title: "-", cmd: "hyphen"},
+			{title: " - -", cmd: "hyphen2"},
 			{title: "----"},
 			{title: "More", children: [
 				{title: "Sub 1 (callback)", action: function(event, ui) { alert("action callback sub1");} },

--- a/jquery.ui-contextmenu.js
+++ b/jquery.ui-contextmenu.js
@@ -531,7 +531,8 @@ $.extend($.moogle.contextmenu, {
 
 		$parentLi.attr("data-command", entry.cmd);
 
-		if ( !/[^\-\u2014\u2013\s]/.test( entry.title ) ) {
+		if ( entry.title === "----" ) {
+		// if ( !/[^\-\u2014\u2013\s]/.test( entry.title ) ) {
 			// hyphen, em dash, en dash: separator as defined by UI Menu 1.10
 			$parentLi.text(entry.title);
 		} else {


### PR DESCRIPTION
Only four hyphens will be recognized as separator.
Update #136